### PR TITLE
Problem: variable name 'url' is too general

### DIFF
--- a/include/fty_common_db_dbpath.h
+++ b/include/fty_common_db_dbpath.h
@@ -31,12 +31,15 @@
 
 #include <string>
 
+namespace DBConn {
+
 #define PASSWD_FILE  "/etc/default/bios-db-rw"
 //! Global string with url to the database
 extern std::string url;
 void dbpath ();
 bool dbreadcredentials();
 
-#endif
+} // namespace
+#endif // __cplusplus
 
 #endif //FTY_COMMON_DB_DBPATH_H

--- a/src/fty_common_db_dbpath.cc
+++ b/src/fty_common_db_dbpath.cc
@@ -27,6 +27,7 @@
 #include <stdlib.h>
 #include <fty_common_filesystem.h>
 
+namespace DBConn {
 static std::string
 s_get_dbpath_wo_trace() {
     std::string s_url =
@@ -92,3 +93,4 @@ bool dbreadcredentials(){
     dbpath();
     return true;
 }
+}// namespace


### PR DESCRIPTION
Solution: namespace created

Signed-off-by: Barbora Stepankova <BarboraStepankova@eaton.com>