### PR TITLE
Problem: std::function requires a header

### DIFF
--- a/include/fty_common_db_asset.h
+++ b/include/fty_common_db_asset.h
@@ -21,6 +21,9 @@
 
 #ifndef FTY_COMMON_DB_ASSET_H_INCLUDED
 #define FTY_COMMON_DB_ASSET_H_INCLUDED
+
+// Note: Consumers MUST be built with C++11 or newer standard due to this:
+#include <functional>
 #include <inttypes.h>
 
 #ifdef __cplusplus


### PR DESCRIPTION
Solution: mention the header in fty_common_db_asset.h; also note consumers MUST be built wiht C++11 or newer

Signed-off-by: Jim Klimov <EvgenyKlimov@eaton.com>