### PR TITLE
Problem: Some definitions appear in both fty-asset and fty-rest.

### DIFF
--- a/include/fty_common_db_asset.h
+++ b/include/fty_common_db_asset.h
@@ -31,6 +31,26 @@
 #ifdef __cplusplus
 #define INPUT_POWER_CHAIN     1
 
+// all fields called name
+#define MAX_NAME_LENGTH         50
+// t_bios_asset_ext_attributes.keytag
+#define MAX_KEYTAG_LENGTH       40
+// t_bios_asset_ext_attributes.value
+#define MAX_VALUE_LENGTH        255
+// t_bios_asset_device.mac
+#define MAX_MAC_LENGTH          17
+// t_bios_asset_device.hostname
+#define MAX_HOSTNAME_LENGTH     25
+// t_bios_asset_device.fullhostname
+#define MAX_FULLHOSTNAME_LENGTH 45
+#define MAX_DESCRIPTION_LENGTH  255
+
+typedef struct _LIMITATIONS_STRUCT
+{
+    int max_active_power_devices;
+    int global_configurability;
+} LIMITATIONS_STRUCT;
+
 typedef std::function<void(const tntdb::Row&)> row_cb_f ;
 
 template <typename T>


### PR DESCRIPTION
Solution: Put them into fty-common-db.

Signed-off-by: Jana Rapava <janarapava@eaton.com>