### PR TITLE
Problem: rest api error code is corrupted,

### DIFF
--- a/include/fty_common_db_defs.h
+++ b/include/fty_common_db_defs.h
@@ -165,12 +165,12 @@ struct db_a_elmnt_t {
 enum errtypes {
     //! First error should be UNKNOWN as it maps to zero and zero is weird
     UNKNOWN_ERR = 0,
-    INTERNAL_ERR = 42,
-    REQUEST_PARAM_BAD_ERR = 47,
-    DATA_CONFLICT_ERR = 50,
-    DB_ERR = 56,
-    BAD_INPUT = 57,
-    LICENSING_ERR = 58,
+    INTERNAL_ERR,
+    REQUEST_PARAM_BAD_ERR,
+    DATA_CONFLICT_ERR,
+    DB_ERR,
+    BAD_INPUT,
+    LICENSING_ERR,
 };
 
 //! Constants for database errors

--- a/include/fty_common_db_defs.h
+++ b/include/fty_common_db_defs.h
@@ -164,13 +164,13 @@ struct db_a_elmnt_t {
 //! Possible error types
 enum errtypes {
     //! First error should be UNKNOWN as it maps to zero and zero is weird
-    UNKNOWN_ERR = 0,
-    INTERNAL_ERR,
-    REQUEST_PARAM_BAD_ERR,
-    DATA_CONFLICT_ERR,
+    UNKNOWN_ERR,
     DB_ERR,
     BAD_INPUT,
+    INTERNAL_ERR,
     LICENSING_ERR,
+    REQUEST_PARAM_BAD_ERR,
+    DATA_CONFLICT_ERR,
 };
 
 //! Constants for database errors


### PR DESCRIPTION
	 http_die_idx recieves index with unexpected value,
	 this is caused by changing index of errors in enum structure fty_common_db/include/fty_common_db_defs.h L168 of
	 https://github.com/42ity/fty-common-db/commit/4680300796a8054e29d039f890f4bfaf810cdcfe#diff-28e4c418276eef88dc297c39a6d0d07bR167

Solution: return to previous state and see if it helps

Signed-off-by: Barbora Stepankova <BarboraStepankova@eaton.com>