### PR TITLE
Problem : fix empty container name

### DIFF
--- a/src/fty_common_db_asset.cc
+++ b/src/fty_common_db_asset.cc
@@ -490,20 +490,22 @@ select_assets_by_container_name_filter (tntdb::Connection &conn,
     uint32_t id = 0;
 
     try {
-        // get container asset id
-        tntdb::Statement select_id = conn.prepareCached(
-            " SELECT "
-            "   v.id "
-            " FROM "
-            "   v_bios_asset_element v "
-            " WHERE "
-            "   v.name = :name "
-        );
+        if (! container_name.empty ()) {
+            // get container asset id
+            tntdb::Statement select_id = conn.prepareCached(
+                " SELECT "
+                "   v.id "
+                " FROM "
+                "   v_bios_asset_element v "
+                " WHERE "
+                "   v.name = :name "
+            );
 
-        tntdb::Row row = select_id.set("name", container_name).
-                            selectRow();
-        row["id"].get(id);
-
+            tntdb::Row row = select_id.set("name", container_name).
+                                selectRow();
+            row["id"].get(id);
+        }
+        //Selects assets in a given container
         std::string request =
             " SELECT "
             "   v.name, "


### PR DESCRIPTION
Problem : asset-autoupdate zactor does a "GET"/_empty/"rackcontroller" request with subject "ASSETS_IN_CONTAINER" goes in 
error fty-asset [140737268848384] -ERROR- select_assets_by_container_name_filter (src/fty_common_db_asset.cc:541) Error:

#6  fty_asset_server (pipe=0x617b80, args=<optimized out>) at src/fty_asset_server.cc:1014
1014	in src/fty_asset_server.cc
(gdb) call mlm_client_sender(cfg->mailbox_client)
$9 = 0x7fffec048e60 "asset-autoupdate"
(gdb) call mlm_client_subject(cfg->mailbox_client)
$10 = 0x7fffec048e7d "ASSETS_IN_CONTAINER"
fty-asset [140737268848384] -ERROR- select_assets_by_container_name_filter (src/fty_common_db_asset.cc:541) Error:

Solution : manage when container_name is empty as it was in fty-asset[release/IPM_Infra-1.4]
Signed-off-by: Gerald Guillaume <geraldguillaume@eaton.com>