### PR TITLE
Implement query for daisy-chained devices

### DIFF
--- a/include/fty_common_db_asset.h
+++ b/include/fty_common_db_asset.h
@@ -311,11 +311,11 @@ namespace DBAssets {
     get_status_from_db (tntdb::Connection conn,
                         std::string &element_name);
 
-// select_daisy_chain: get daisy-chain of which element_id is part based on
+// select_daisy_chain: get daisy-chain of which asset is part based on
 // daisy_chain ext properties, or empty map if not part of a daisy-chain
-// (1 -> assetId1, 2 -> assetId2...)
-    db_reply <std::map <int, uint32_t> >
-    select_daisy_chain (tntdb::Connection &conn, uint32_t element_id);
+// (1 -> asset1, 2 -> asset2...)
+    db_reply <std::map <int, std::string> >
+    select_daisy_chain (tntdb::Connection &conn, const std::string &asset);
 } // namespace
 
 void

--- a/include/fty_common_db_asset.h
+++ b/include/fty_common_db_asset.h
@@ -311,11 +311,11 @@ namespace DBAssets {
     get_status_from_db (tntdb::Connection conn,
                         std::string &element_name);
 
-// select_daisy_chain: get daisy-chain of which asset is part based on
+// select_daisy_chain: get daisy-chain of which asset_id is part based on
 // daisy_chain ext properties, or empty map if not part of a daisy-chain
-// (1 -> asset1, 2 -> asset2...)
+// (1 -> asset_internal_name_1, 2 -> asset_internal_name_2...)
     db_reply <std::map <int, std::string> >
-    select_daisy_chain (tntdb::Connection &conn, const std::string &asset);
+    select_daisy_chain (tntdb::Connection &conn, const std::string &asset_id);
 } // namespace
 
 void

--- a/include/fty_common_db_asset.h
+++ b/include/fty_common_db_asset.h
@@ -310,6 +310,12 @@ namespace DBAssets {
     std::string
     get_status_from_db (tntdb::Connection conn,
                         std::string &element_name);
+
+// select_daisy_chain: get daisy-chain of which element_id is part based on
+// daisy_chain ext properties, or empty map if not part of a daisy-chain
+// (1 -> assetId1, 2 -> assetId2...)
+    db_reply <std::map <int, uint32_t> >
+    select_daisy_chain (tntdb::Connection &conn, uint32_t element_id);
 } // namespace
 
 void

--- a/src/fty_common_db_asset.cc
+++ b/src/fty_common_db_asset.cc
@@ -1822,10 +1822,10 @@ get_status_from_db (tntdb::Connection conn,
 }
 
 db_reply <std::map <int, std::string> >
-select_daisy_chain (tntdb::Connection &conn, const std::string &asset)
+select_daisy_chain (tntdb::Connection &conn, const std::string &asset_id)
 {
     LOG_START;
-    log_debug ("  asset = %s", asset.c_str());
+    log_debug ("  asset_id = %s", asset_id.c_str());
     std::map <int, std::string> item{};
     db_reply <std::map <int, std::string> > ret = db_reply_new(item);
 
@@ -1842,7 +1842,7 @@ select ae_name_out.name, aea_daisychain.value as daisy_chain
                 (
                     select ae_name_in.id_asset_element
                         from t_bios_asset_element ae_name_in
-                        where ae_name_in.name = :asset
+                        where ae_name_in.name = :asset_id
                 ) and aea_ip.keytag like 'ip.%'
         )
     )
@@ -1850,7 +1850,7 @@ select ae_name_out.name, aea_daisychain.value as daisy_chain
     try{
         // Can return more than one row.
         tntdb::Statement st = conn.prepareCached(query);
-        tntdb::Result result = st.set("asset", asset).select();
+        tntdb::Result result = st.set("asset_id", asset_id).select();
 
         // Go through the selected elements
         for (auto const& row: result) {


### PR DESCRIPTION
We need the ability to query daisy-chains of ePDUs (or other things) in order to map FTY assets to NUT assets for power commands.